### PR TITLE
feat: add copy exec command button for running containers

### DIFF
--- a/frontend/src/pages/Containers.tsx
+++ b/frontend/src/pages/Containers.tsx
@@ -15,7 +15,7 @@ import {
   Alert,
   Code,
 } from '@mantine/core';
-import { IconRefresh, IconPlayerPlay, IconPlayerPause, IconTrash, IconSearch } from '@tabler/icons-react';
+import { IconRefresh, IconPlayerPlay, IconPlayerPause, IconTrash, IconSearch, IconTerminal } from '@tabler/icons-react';
 import { containerApi, type ContainerInfo } from '../api/containers';
 import { notifications } from '@mantine/notifications';
 
@@ -123,6 +123,28 @@ export function Containers() {
   const openDeleteModal = (container: ContainerInfo) => {
     setSelectedContainer(container);
     setDeleteModalOpen(true);
+  };
+
+  const handleCopyCommand = async (containerId: string, containerName: string) => {
+    // Use /bin/sh for Alpine-based images, /bin/bash for others
+    const shell = containerName.toLowerCase().includes('alpine') ? '/bin/sh' : '/bin/bash';
+    const command = `docker exec -it ${truncateId(containerId)} ${shell}`;
+
+    try {
+      await navigator.clipboard.writeText(command);
+      notifications.show({
+        title: 'Command Copied',
+        message: `Exec command copied to clipboard`,
+        color: 'blue',
+      });
+    } catch (error) {
+      notifications.show({
+        title: 'Error',
+        message: 'Failed to copy command to clipboard',
+        color: 'red',
+      });
+      console.error('Failed to copy to clipboard:', error);
+    }
   };
 
   const getStateBadgeColor = (state: string) => {
@@ -248,14 +270,24 @@ export function Containers() {
                     <Table.Td>
                       <Group gap="xs">
                         {container.state.toLowerCase() === 'running' ? (
-                          <ActionIcon
-                            color="yellow"
-                            variant="light"
-                            onClick={() => handleStop(container.id, container.name)}
-                            title="Stop container"
-                          >
-                            <IconPlayerPause size={16} />
-                          </ActionIcon>
+                          <>
+                            <ActionIcon
+                              color="blue"
+                              variant="light"
+                              onClick={() => handleCopyCommand(container.id, container.name)}
+                              title="Copy exec command"
+                            >
+                              <IconTerminal size={16} />
+                            </ActionIcon>
+                            <ActionIcon
+                              color="yellow"
+                              variant="light"
+                              onClick={() => handleStop(container.id, container.name)}
+                              title="Stop container"
+                            >
+                              <IconPlayerPause size={16} />
+                            </ActionIcon>
+                          </>
                         ) : (
                           <ActionIcon
                             color="green"

--- a/frontend/src/pages/Containers.tsx
+++ b/frontend/src/pages/Containers.tsx
@@ -125,9 +125,9 @@ export function Containers() {
     setDeleteModalOpen(true);
   };
 
-  const handleCopyCommand = async (containerId: string, containerName: string) => {
+  const handleCopyCommand = async (containerId: string, containerImage: string) => {
     // Use /bin/sh for Alpine-based images, /bin/bash for others
-    const shell = containerName.toLowerCase().includes('alpine') ? '/bin/sh' : '/bin/bash';
+    const shell = containerImage.toLowerCase().includes('alpine') ? '/bin/sh' : '/bin/bash';
     const command = `docker exec -it ${truncateId(containerId)} ${shell}`;
 
     try {
@@ -274,8 +274,8 @@ export function Containers() {
                             <ActionIcon
                               color="blue"
                               variant="light"
-                              onClick={() => handleCopyCommand(container.id, container.name)}
-                              title="Copy exec command"
+                              onClick={() => handleCopyCommand(container.id, container.image)}
+                              title="Copy docker exec command"
                             >
                               <IconTerminal size={16} />
                             </ActionIcon>


### PR DESCRIPTION
## Summary
Resolves #17

実行中のコンテナにアクセスするための`docker exec`コマンドをワンクリックでコピーできる機能を追加しました。

## Changes
- Containersページの実行中コンテナに**ターミナルアイコンボタン**を追加
- クリックでクリップボードに`docker exec -it <container_id> <shell>`をコピー
- シェルの自動検出機能（Alpine系は`/bin/sh`、その他は`/bin/bash`）
- コピー成功時にトースト通知を表示
- エラーハンドリングを実装

## UI
- **ターミナルアイコン**（青色）: 実行中のコンテナのみに表示
- **停止アイコン**（黄色）: 既存のストップボタン
- **削除アイコン**（赤色）: 既存の削除ボタン

## Benefits
- ユーザーが手動でコンテナIDを入力する手間を削減
- シェルの種類を自動で判定して適切なコマンドを生成
- 開発フローがスムーズになる

## Test plan
- [ ] npm run buildが成功することを確認
- [ ] Containersページで以下をテスト：
  1. 実行中のコンテナにターミナルアイコンが表示されることを確認
  2. ターミナルアイコンをクリック
  3. クリップボードにコマンドがコピーされたことを確認
  4. トースト通知が表示されることを確認
  5. コピーしたコマンドをターミナルで実行してコンテナにアクセスできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)