### PR TITLE
feat: add SSH server support to generated containers

### DIFF
--- a/frontend/src/components/DockerfilePreview.tsx
+++ b/frontend/src/components/DockerfilePreview.tsx
@@ -95,8 +95,9 @@ export const DockerfilePreview: React.FC<DockerfilePreviewProps> = ({ config }) 
 
     try {
       // Add SSH port mapping if SSH is enabled
+      // Format: { "container_port": "host_port" }
       const ports = config.ssh?.enabled && config.ssh.port
-        ? { [`${config.ssh.port}`]: '22' }
+        ? { '22': `${config.ssh.port}` }
         : undefined;
 
       // Add timestamp to make container name unique

--- a/frontend/src/components/DockerfilePreview.tsx
+++ b/frontend/src/components/DockerfilePreview.tsx
@@ -99,8 +99,11 @@ export const DockerfilePreview: React.FC<DockerfilePreviewProps> = ({ config }) 
         ? { [`${config.ssh.port}`]: '22' }
         : undefined;
 
+      // Add timestamp to make container name unique
+      const uniqueContainerName = `${containerName}-${Date.now()}`;
+
       const result = await apiClient.runContainer(builtImageTag, {
-        name: containerName,
+        name: uniqueContainerName,
         ports,
       });
       setContainerId(result.container_id);
@@ -211,24 +214,40 @@ export const DockerfilePreview: React.FC<DockerfilePreviewProps> = ({ config }) 
               <Stack gap="sm">
                 <Group gap="sm">
                   <Loader size="sm" />
-                  <Text fw={500} size="sm">Building image...</Text>
+                  <Text fw={500} size="sm">Building Docker image...</Text>
                 </Group>
+                <Text size="sm" c="dimmed">
+                  This may take a few minutes depending on the selected languages and packages.
+                </Text>
               </Stack>
             </Paper>
           )}
 
           {buildLogs.length > 0 && (
-            <Stack gap="xs">
-              <Text fw={500}>Build Logs:</Text>
-              <Code block style={{
-                whiteSpace: 'pre-wrap',
-                fontFamily: 'monospace',
-                maxHeight: '300px',
-                overflowY: 'auto'
-              }}>
-                {buildLogs.join('')}
-              </Code>
-            </Stack>
+            <Paper withBorder p="md">
+              <Stack gap="md">
+                <Group gap="sm">
+                  <Text fw={600} size="md">📋 Build Logs</Text>
+                  {building && <Loader size="xs" />}
+                </Group>
+                <Code
+                  block
+                  style={{
+                    whiteSpace: 'pre-wrap',
+                    fontFamily: 'monospace',
+                    fontSize: '12px',
+                    maxHeight: '400px',
+                    overflowY: 'auto',
+                    backgroundColor: '#1e1e1e',
+                    color: '#d4d4d4',
+                    padding: '12px',
+                    borderRadius: '4px',
+                  }}
+                >
+                  {buildLogs.join('')}
+                </Code>
+              </Stack>
+            </Paper>
           )}
 
           {builtImageTag && !containerId && (

--- a/frontend/src/components/DockerfilePreview.tsx
+++ b/frontend/src/components/DockerfilePreview.tsx
@@ -100,12 +100,18 @@ export const DockerfilePreview: React.FC<DockerfilePreviewProps> = ({ config }) 
         ? { '22': `${config.ssh.port}` }
         : undefined;
 
+      // Add ROOT_PASSWORD environment variable if SSH is enabled
+      const env = config.ssh?.enabled && config.ssh.password
+        ? [`ROOT_PASSWORD=${config.ssh.password}`]
+        : undefined;
+
       // Add timestamp to make container name unique
       const uniqueContainerName = `${containerName}-${Date.now()}`;
 
       const result = await apiClient.runContainer(builtImageTag, {
         name: uniqueContainerName,
         ports,
+        env,
       });
       setContainerId(result.container_id);
     } catch (err) {

--- a/frontend/src/components/DockerfilePreview.tsx
+++ b/frontend/src/components/DockerfilePreview.tsx
@@ -94,8 +94,14 @@ export const DockerfilePreview: React.FC<DockerfilePreviewProps> = ({ config }) 
     setContainerId(null);
 
     try {
+      // Add SSH port mapping if SSH is enabled
+      const ports = config.ssh?.enabled && config.ssh.port
+        ? { [`${config.ssh.port}`]: '22' }
+        : undefined;
+
       const result = await apiClient.runContainer(builtImageTag, {
         name: containerName,
+        ports,
       });
       setContainerId(result.container_id);
     } catch (err) {
@@ -127,6 +133,11 @@ export const DockerfilePreview: React.FC<DockerfilePreviewProps> = ({ config }) 
             <Text size="sm" c="dimmed">
               Languages: {config.languages.map(lang => `${lang.name} ${lang.version}`).join(', ')}
             </Text>
+            {config.ssh?.enabled && (
+              <Text size="sm" c="dimmed">
+                SSH Server: Enabled (Port {config.ssh.port})
+              </Text>
+            )}
           </div>
         </Stack>
       </Paper>

--- a/frontend/src/components/SshConfiguration.tsx
+++ b/frontend/src/components/SshConfiguration.tsx
@@ -52,11 +52,12 @@ export function SshConfiguration({ config, onConfigChange }: SshConfigurationPro
 
           <PasswordInput
             label="Root Password"
-            description="Password for root user SSH access"
-            placeholder="Enter a secure password"
+            description="Password for root user SSH access (minimum 6 characters)"
+            placeholder="Enter a secure password (min 6 characters)"
             value={config.password}
             onChange={handlePasswordChange}
             leftSection={<IconKey size={16} />}
+            error={config.password.length > 0 && config.password.length < 6 ? 'Password must be at least 6 characters' : undefined}
             required
           />
 

--- a/frontend/src/components/SshConfiguration.tsx
+++ b/frontend/src/components/SshConfiguration.tsx
@@ -1,0 +1,70 @@
+import { Stack, Title, Text, Switch, NumberInput, PasswordInput } from '@mantine/core';
+import { IconKey } from '@tabler/icons-react';
+import type { SshConfig } from '../types/config';
+
+interface SshConfigurationProps {
+  config: SshConfig;
+  onConfigChange: (config: SshConfig) => void;
+}
+
+export function SshConfiguration({ config, onConfigChange }: SshConfigurationProps) {
+  const handleEnabledChange = (enabled: boolean) => {
+    onConfigChange({ ...config, enabled });
+  };
+
+  const handlePortChange = (port: number | string) => {
+    onConfigChange({ ...config, port: Number(port) });
+  };
+
+  const handlePasswordChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onConfigChange({ ...config, password: event.currentTarget.value });
+  };
+
+  return (
+    <Stack gap="xl">
+      <Stack gap="xs">
+        <Title order={2}>SSH Server Configuration</Title>
+        <Text c="dimmed">
+          Enable SSH server for remote access to the container.
+        </Text>
+      </Stack>
+
+      <Switch
+        label="Enable SSH Server"
+        description="Allow remote SSH connections to the container"
+        checked={config.enabled}
+        onChange={(event) => handleEnabledChange(event.currentTarget.checked)}
+        size="md"
+      />
+
+      {config.enabled && (
+        <Stack gap="md">
+          <NumberInput
+            label="SSH Port"
+            description="Port to expose SSH server on the host machine"
+            placeholder="2222"
+            value={config.port}
+            onChange={handlePortChange}
+            min={1024}
+            max={65535}
+            required
+          />
+
+          <PasswordInput
+            label="Root Password"
+            description="Password for root user SSH access"
+            placeholder="Enter a secure password"
+            value={config.password}
+            onChange={handlePasswordChange}
+            leftSection={<IconKey size={16} />}
+            required
+          />
+
+          <Text size="sm" c="orange">
+            Warning: For production use, consider using SSH key-based authentication instead of password authentication.
+          </Text>
+        </Stack>
+      )}
+    </Stack>
+  );
+}

--- a/frontend/src/constants/options.ts
+++ b/frontend/src/constants/options.ts
@@ -10,4 +10,4 @@ export const LANGUAGE_OPTIONS = [
   { name: 'rust', displayName: 'Rust', versions: ['stable', 'nightly'] },
 ] as const;
 
-export const TOTAL_STEPS = 3;
+export const TOTAL_STEPS = 4;

--- a/frontend/src/pages/Containers.tsx
+++ b/frontend/src/pages/Containers.tsx
@@ -148,11 +148,15 @@ export function Containers() {
   };
 
   const handleCopySSHCommand = async (ports: ContainerInfo['ports']) => {
-    // Find SSH port mapping (port 22)
-    const sshPort = ports.find(p => p.private_port === 22);
-    if (!sshPort || !sshPort.public_port) return;
+    // Find SSH port mapping (port 22 in either private or public port)
+    const sshPort = ports.find(p => p.private_port === 22 || p.public_port === 22);
+    if (!sshPort) return;
 
-    const command = `ssh -p ${sshPort.public_port} root@localhost`;
+    // Determine which port is the host port (the one that's not 22)
+    const hostPort = sshPort.private_port === 22 ? sshPort.public_port : sshPort.private_port;
+    if (!hostPort) return;
+
+    const command = `ssh -p ${hostPort} root@localhost`;
 
     try {
       await navigator.clipboard.writeText(command);
@@ -303,7 +307,7 @@ export function Containers() {
                             >
                               <IconTerminal size={16} />
                             </ActionIcon>
-                            {container.ports.some(p => p.private_port === 22) && (
+                            {container.ports.some(p => p.private_port === 22 || p.public_port === 22) && (
                               <ActionIcon
                                 color="cyan"
                                 variant="light"

--- a/frontend/src/pages/Generator.tsx
+++ b/frontend/src/pages/Generator.tsx
@@ -2,8 +2,9 @@ import { useState, useEffect } from 'react';
 import { StepLayout } from '../components/StepLayout';
 import { OSSelection } from '../components/OSSelection';
 import { LanguageSelection } from '../components/LanguageSelection';
+import { SshConfiguration } from '../components/SshConfiguration';
 import { DockerfilePreview } from '../components/DockerfilePreview';
-import type { EnvironmentConfig, OsConfig, Language } from '../types/config';
+import type { EnvironmentConfig, OsConfig, Language, SshConfig } from '../types/config';
 import { TOTAL_STEPS } from '../constants/options';
 
 const STORAGE_KEY = 'containerHelper.generatorState';
@@ -44,6 +45,11 @@ export function Generator() {
     initialState?.config ?? {
       os: { type: '', version: '' },
       languages: [],
+      ssh: {
+        enabled: false,
+        port: 2222,
+        password: '',
+      },
     }
   );
 
@@ -76,12 +82,22 @@ export function Generator() {
     setConfig(prev => ({ ...prev, languages }));
   };
 
+  const handleSshConfigChange = (ssh: SshConfig) => {
+    setConfig(prev => ({ ...prev, ssh }));
+  };
+
   const isNextDisabled = () => {
     switch (currentStep) {
       case 1:
         return !config.os.type || !config.os.version;
       case 2:
         return config.languages.length === 0;
+      case 3:
+        // SSH設定が有効な場合、パスワードが必須
+        if (config.ssh?.enabled) {
+          return !config.ssh.password || config.ssh.password.length < 6;
+        }
+        return false;
       default:
         return false;
     }
@@ -104,6 +120,13 @@ export function Generator() {
           />
         );
       case 3:
+        return (
+          <SshConfiguration
+            config={config.ssh || { enabled: false, port: 2222, password: '' }}
+            onConfigChange={handleSshConfigChange}
+          />
+        );
+      case 4:
         return (
           <DockerfilePreview
             config={config}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -52,6 +52,11 @@ export const apiClient = {
           name: lang.name,
           version: lang.version,
         })),
+        ssh: config.ssh ? {
+          enabled: config.ssh.enabled,
+          port: config.ssh.port,
+          password: config.ssh.password,
+        } : undefined,
       }),
     });
 

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -8,8 +8,15 @@ export interface Language {
   version: string;
 }
 
+export interface SshConfig {
+  enabled: boolean;
+  port: number;
+  password: string;
+}
+
 export interface EnvironmentConfig {
   name?: string;
   os: OsConfig;
   languages: Language[];
+  ssh?: SshConfig;
 }

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -12,9 +12,17 @@ pub struct Language {
     pub version: String,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SshConfig {
+    pub enabled: bool,
+    pub port: u16,
+    pub password: String,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EnvironmentConfig {
     pub name: Option<String>,
     pub os: OsConfig,
     pub languages: Vec<Language>,
+    pub ssh: Option<SshConfig>,
 }

--- a/src/routes/container.rs
+++ b/src/routes/container.rs
@@ -39,14 +39,15 @@ pub struct RunResponse {
 pub fn container_routes() -> Router<Arc<DockerService>> {
     Router::new()
         .route("/api/containers", get(list_containers))
+        // Specific routes must come before parameterized routes
+        .route("/api/containers/build", post(build_image))
+        .route("/api/containers/run", post(run_container))
         .route(
             "/api/containers/:id",
             get(get_container).delete(remove_container),
         )
         .route("/api/containers/:id/start", post(start_container))
         .route("/api/containers/:id/stop", post(stop_container))
-        .route("/api/containers/build", post(build_image))
-        .route("/api/containers/run", post(run_container))
 }
 
 async fn list_containers(

--- a/src/services/docker_service.rs
+++ b/src/services/docker_service.rs
@@ -226,6 +226,8 @@ impl DockerService {
         ports: Option<HashMap<String, String>>,
     ) -> Result<String> {
         let mut port_bindings = HashMap::new();
+        let mut exposed_ports = HashMap::new();
+
         if let Some(ports_map) = ports {
             for (container_port, host_port) in ports_map {
                 // Docker requires port keys to include protocol (e.g., "8080/tcp")
@@ -234,6 +236,11 @@ impl DockerService {
                 } else {
                     format!("{}/tcp", container_port)
                 };
+
+                // Add to exposed ports
+                exposed_ports.insert(port_key.clone(), HashMap::new());
+
+                // Add to port bindings
                 port_bindings.insert(
                     port_key,
                     Some(vec![bollard::service::PortBinding {
@@ -247,6 +254,11 @@ impl DockerService {
         let config = ContainerConfig {
             image: Some(image.to_string()),
             env,
+            exposed_ports: if exposed_ports.is_empty() {
+                None
+            } else {
+                Some(exposed_ports)
+            },
             host_config: Some(bollard::service::HostConfig {
                 port_bindings: Some(port_bindings),
                 ..Default::default()

--- a/src/services/dockerfile_generator.rs
+++ b/src/services/dockerfile_generator.rs
@@ -59,7 +59,7 @@ pub fn generate_dockerfile(config: &EnvironmentConfig) -> String {
     lines.push("# Set default command".to_string());
 
     // Use sshd if SSH is enabled, otherwise bash
-    if config.ssh.as_ref().map_or(false, |s| s.enabled) {
+    if config.ssh.as_ref().is_some_and(|s| s.enabled) {
         lines.push("CMD [\"/usr/sbin/sshd\", \"-D\"]".to_string());
     } else {
         lines.push("CMD [\"/bin/bash\"]".to_string());

--- a/src/services/dockerfile_generator.rs
+++ b/src/services/dockerfile_generator.rs
@@ -36,8 +36,13 @@ pub fn generate_dockerfile(config: &EnvironmentConfig) -> String {
             // Add entrypoint script to set password at runtime
             lines.push("# Create entrypoint script to set password securely".to_string());
             lines.push("RUN echo '#!/bin/sh' > /entrypoint.sh && \\".to_string());
-            lines.push("    echo 'if [ -n \"$ROOT_PASSWORD\" ]; then' >> /entrypoint.sh && \\".to_string());
-            lines.push("    echo '  echo \"root:$ROOT_PASSWORD\" | chpasswd' >> /entrypoint.sh && \\".to_string());
+            lines.push(
+                "    echo 'if [ -n \"$ROOT_PASSWORD\" ]; then' >> /entrypoint.sh && \\".to_string(),
+            );
+            lines.push(
+                "    echo '  echo \"root:$ROOT_PASSWORD\" | chpasswd' >> /entrypoint.sh && \\"
+                    .to_string(),
+            );
             lines.push("    echo 'fi' >> /entrypoint.sh && \\".to_string());
             lines.push("    echo 'exec \"$@\"' >> /entrypoint.sh && \\".to_string());
             lines.push("    chmod +x /entrypoint.sh".to_string());


### PR DESCRIPTION
## Summary
Resolves #19

コンテナにSSHサーバーを組み込み、リモート端末から直接SSH接続できる機能を実装しました。

## Features

### Generator Workflow
1. **Step 3: SSH Configuration** (新規追加)
   - SSH Server有効化トグル
   - SSHポート番号設定（デフォルト: 2222）
   - Rootパスワード設定（最低6文字）
   - セキュリティ警告メッセージ

2. **Step 4: Dockerfile Preview**（旧Step 3から移動）

### Generated Dockerfile
SSH有効時、Dockerfileに以下が含まれます：
- openssh-serverのインストール（OS別: apt-get/apk）
- SSH host key生成
- rootパスワード設定
- PermitRootLogin, PasswordAuthenticationを有効化
- SSHポート公開（EXPOSE）
- CMDをsshdデーモンに変更

### Containers Page
- **SSHコマンドコピー機能**
  - ポート22が公開されているコンテナに鍵アイコン表示
  - クリックで`ssh -p <port> root@localhost`をコピー
  - トースト通知でフィードバック
- **Docker Execコマンドコピー**（既存機能）
  - 全ての実行中コンテナにターミナルアイコン表示

## Implementation Details

### Frontend
- 新規コンポーネント: `SshConfiguration.tsx`
- 型定義: `SshConfig` interface（enabled, port, password）
- Dockerfile生成ロジック更新: `getSSHInstallCommands()`
- ポートマッピング: コンテナ実行時に自動設定
- LocalStorage: SSH設定も保存・復元対象

### Backend
- Rustモデル更新: `SshConfig` struct追加
- `EnvironmentConfig`に`ssh: Option<SshConfig>`追加
- ポートマッピングは既存実装で対応可能

## Security Notes

⚠️ **現在の実装**:
- パスワード認証方式
- root直接ログイン有効

⚠️ **本番環境推奨**:
- 公開鍵認証の使用
- 一般ユーザー作成＋sudo設定
- ファイアウォール設定

UIに警告メッセージを表示しています。

## Test Plan

- [ ] フロントエンドビルド成功（`npm run build`）
- [ ] バックエンドビルド成功（`cargo check`）
- [ ] Generatorで以下をテスト：
  1. SSH Server有効化
  2. ポート番号変更（例: 2223）
  3. パスワード設定（6文字以上）
  4. Step 4でDockerfileにSSH設定が含まれることを確認
  5. ビルド＆実行
- [ ] Containersページで：
  1. 実行中コンテナに鍵アイコンが表示される
  2. アイコンクリックでSSHコマンドがコピーされる
  3. 別ターミナルでコピーしたコマンドを実行
  4. `ssh -p 2222 root@localhost`で接続成功
  5. 設定したパスワードで認証成功

## Screenshots

SSH Configuration Step:
- トグルスイッチでON/OFF
- ポート番号入力フィールド
- パスワード入力フィールド（隠し文字）
- セキュリティ警告メッセージ

Containers Page:
- 鍵アイコン（cyan色）がポート22公開コンテナに表示
- ターミナルアイコン（blue色）が全実行中コンテナに表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)